### PR TITLE
Add foca.debug_info() to dump current knowledge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.8.0 - 2022-12-31
+
+- Bugfix: foca would send garbage at the end of the payload when
+  replying to Announce messages under certain scenarios.
+  See: https://github.com/caio/foca/issues/18
+
 ## v0.7.0 - 2022-11-27
 
 - **BREAKING**: `Config::remove_down_after` now defaults to 2 minutes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "foca"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Caio <contact@caio.co>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/src/broadcast.rs
+++ b/src/broadcast.rs
@@ -116,6 +116,11 @@ where
         self.storage.len()
     }
 
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &Entry<T>> {
+        // reversed because this is how we traverse it for fill()
+        self.storage.iter().rev()
+    }
+
     pub fn add_or_replace(&mut self, value: T, max_tx: usize) {
         let new_node = Entry {
             remaining_tx: max_tx,
@@ -214,9 +219,9 @@ where
 }
 
 #[derive(Debug, Clone)]
-struct Entry<T> {
-    remaining_tx: usize,
-    value: T,
+pub(crate) struct Entry<T> {
+    pub(crate) remaining_tx: usize,
+    pub(crate) value: T,
 }
 
 impl<T: AsRef<[u8]>> PartialEq for Entry<T> {

--- a/src/member.rs
+++ b/src/member.rs
@@ -139,14 +139,11 @@ pub(crate) struct Members<T> {
     num_active: usize,
 }
 
-#[cfg(test)]
-impl<T> Members<T> {
-    pub fn len(&self) -> usize {
+impl<T: PartialEq + Clone> Members<T> {
+    pub(crate) fn len(&self) -> usize {
         self.inner.len()
     }
-}
 
-impl<T: PartialEq + Clone> Members<T> {
     pub fn num_active(&self) -> usize {
         self.num_active
     }


### PR DESCRIPTION
here's what i think will help diagnose the backlog problem

you should:

1. ship it to a node (just one suffices)
2. wait for its backlog to become massive
3. call `foca.debug_info()` on it, save it somewhere

only need to do this once

here's what the dump looks like, with some annotations to help understand what you're seeing and explain what i _think_ the problem scenario is

this is from a few local instances of the insecure agent example, after i ^c'ed a couple. it's a plain serde_json::to_string output


```jsonc
{
  "current_identity": {
    "addr": "[::1]:8083",
    "bump": 53196
  },

  // how many members this instance knows about
  // members here means distinct identities (i.e. not keyed by ActorId in your case)
  "total_members": 3,

  "active_members": 3, // foca.num_members
  "backlog_len": 2, // foca.updates_backlog
  
  // for every message, foca walks this data and tries to fit it
  // into the payload (an entry gets added it `data_len` fits the remaining
  // capacity in the buffer; when that happens, `remaining_tx` is decreased
  // and removed if it reaches zero)
  "backlog": [
    {
      // key is the member_id the data is about. it's supposed to be
      // the exact same as decoded_data.id- just so that it's easy to
      // find/replace things without having do decode stuff all the time
      "key": {
        "addr": "[::1]:8081",
        "bump": 6695
      },
      "reamining_tx": 7,
      "data_len": 23,
      "decoded_data": {
        "id": {
          "addr": "[::1]:8081",
          "bump": 6695
        },
        "incarnation": 0,
        "state": "Suspect"
      }
    },
    {
      "key": {
        "addr": "[::1]:8082",
        "bump": 61144
      },
      "reamining_tx": 1,
      "data_len": 24,
      "decoded_data": {
        "id": {
          "addr": "[::1]:8082",
          "bump": 61144
        },
        "incarnation": 0,
        "state": "Suspect"
      }
    }
  ]
}
```

(the pr includes the commits for v0.8.0 so it looks larger than it is- the actual commit is d3088feeb6bc67cf1a515bfda4e05cbb5dc26a2f)